### PR TITLE
docker2nix section needs a default-language directive

### DIFF
--- a/hocker.cabal
+++ b/hocker.cabal
@@ -203,6 +203,9 @@ executable docker2nix
                optional-args,
                hocker
 
+
+ default-language:    Haskell2010
+
 test-suite hocker-tests
   type:                exitcode-stdio-1.0
   hs-source-dirs:      test


### PR DESCRIPTION
This is necessary if we specify `cabal-version:  >= 1.10`, otherwise the package will not pass validation on Hackage.