### PR TITLE
Revert "Only accept the image manifest format"

### DIFF
--- a/src/Network/Wreq/Docker/Registry.hs
+++ b/src/Network/Wreq/Docker/Registry.hs
@@ -120,7 +120,9 @@ fetchManifest = ask >>= \HockerMeta{..} ->
   where
     mkURL (ImageName n) (ImageTag t) r = C8.unpack (serializeURIRef' $ Hocker.Lib.joinURIPath [n, "manifests", t] r)
     accept = Wreq.header "Accept" .~
-      [ "application/vnd.docker.distribution.manifest.v2+json" ]
+      [ "application/vnd.docker.distribution.manifest.v2+json"
+      , "application/vnd.docker.distribution.manifest.list.v2+json"
+      ]
 
 -- | Retrieve the configuratino JSON of an image by its hash digest
 -- (found in the V2 manifest for an image given by a name and a tag).


### PR DESCRIPTION
This reverts commit 3463253597a264ef12085cbdeb35a04531f59679.

I had an oopsie, thought I was pushing to a branch but it was `master`. I want to revert this commit and re-do the change as a PR.