### PR TITLE
Fix response integrity check bug (#23) and fix missing tests data

### DIFF
--- a/hocker.cabal
+++ b/hocker.cabal
@@ -36,6 +36,9 @@ extra-source-files:
   README.md
   CHANGELOG.md
 
+data-dir:
+  test/data
+
 source-repository head
   type:     git
   location: https://github.com/awakesecurity/hocker.git

--- a/src/Network/Wreq/Docker/Image.hs
+++ b/src/Network/Wreq/Docker/Image.hs
@@ -111,7 +111,7 @@ fetchLayer =
     writeC <- liftIO $ getConcurrentOutputter
     liftIO . writeC . Text.unpack $ "Downloading layer: " <> shortRef
 
-    fetchedImageLayer <- checkResponseIntegrity' =<< Docker.Registry.fetchLayer ("sha256:" <> layerDigest)
+    fetchedImageLayer <- Docker.Registry.fetchLayer ("sha256:" <> layerDigest)
     layerPath         <- writeRespBody layerOut layerDigest fetchedImageLayer
 
     liftIO . writeC $ Text.unpack ("=> wrote " <> shortRef)
@@ -125,7 +125,6 @@ fetchConfig =
   runHocker $ ask >>= \HockerMeta{..} -> do
     configDigest <-
       fetchManifest
-        >>= checkResponseIntegrity'
         >>= getConfigDigest . view Wreq.responseBody
 
     fetchImageConfig configDigest


### PR DESCRIPTION
This change is being made because the `Docker-Content-Digest` value sent back by docker distribution is a hash digest from the image manifest list when only the image manifest is accepted by the client.

This issue on docker distribution tracks the regression: https://github.com/docker/distribution/issues/2395

Fixes #23

Issue #24 tracks reverting this change when the docker distribution issue is resolved.

This change also fixes a test failure caused by the tests data dir not being included in the cabal source distribution.