### PR TITLE
Add readField implementations to custom ParseField instances

### DIFF
--- a/nix/optparse-generic.nix
+++ b/nix/optparse-generic.nix
@@ -1,13 +1,14 @@
-{ mkDerivation, base, bytestring, optparse-applicative, semigroups
-, stdenv, system-filepath, text, time, transformers, void
+{ mkDerivation, base, bytestring, Only, optparse-applicative
+, semigroups, stdenv, system-filepath, text, time, transformers
+, void
 }:
 mkDerivation {
   pname = "optparse-generic";
-  version = "1.2.1";
-  sha256 = "1dk945dp98mwk1v4y0cky3z0ngmd29nbg6fbaaxnigcrgpbvkjml";
+  version = "1.2.3";
+  sha256 = "1wxzpj4xj3bafg3piarwsr69xxzp75fdglx9c3spbahl1aq9wzgk";
   libraryHaskellDepends = [
-    base bytestring optparse-applicative semigroups system-filepath
-    text time transformers void
+    base bytestring Only optparse-applicative semigroups
+    system-filepath text time transformers void
   ];
   description = "Auto-generate a command-line parser for your datatype";
   license = stdenv.lib.licenses.bsd3;

--- a/src/Hocker/Types.hs
+++ b/src/Hocker/Types.hs
@@ -157,6 +157,7 @@ data Credentials = Basic Username Password | BearerToken Text
   deriving (Show)
 
 instance ParseField Credentials where
+  readField = Options.readerError "Internal, fatal error: unexpected use of readField"
   parseField _ _ _ = (Basic <$> parseUsername <*> parsePassword) <|> (BearerToken <$> parseToken)
     where
       parseUsername = Text.pack <$>

--- a/src/Hocker/Types/Hash.hs
+++ b/src/Hocker/Types/Hash.hs
@@ -29,6 +29,7 @@ readSHA256 :: C8.ByteString -> Maybe (Hash.Digest Hash.SHA256)
 readSHA256 = either (const Nothing) Hash.digestFromByteString . toBytes
 
 instance ParseField (Hash.Digest Hash.SHA256) where
+  readField = Options.maybeReader (readSHA256 . C8.pack)
   parseField h _ _ =
       (Options.option (Options.maybeReader (readSHA256 . C8.pack)) $
        ( Options.metavar "SHA256"

--- a/src/Hocker/Types/ImageName.hs
+++ b/src/Hocker/Types/ImageName.hs
@@ -23,6 +23,7 @@ newtype ImageName = ImageName { unImageName :: String }
   deriving (Generic, Show)
 
 instance ParseField ImageName where
+  readField = ImageName <$> Options.str
   parseField _ _ _ =
     ImageName <$>
       (Options.argument Options.str $

--- a/src/Hocker/Types/ImageTag.hs
+++ b/src/Hocker/Types/ImageTag.hs
@@ -23,6 +23,7 @@ newtype ImageTag = ImageTag { unImageTag :: String }
   deriving (Generic, Show)
 
 instance ParseField ImageTag where
+  readField = ImageTag <$> Options.str
   parseField _ _ _ =
     ImageTag <$>
       (Options.argument Options.str $

--- a/src/Hocker/Types/URI.hs
+++ b/src/Hocker/Types/URI.hs
@@ -31,6 +31,7 @@ uriReader = Options.eitherReader parseURIArg
       over _Left show parsedURI
 
 instance ParseField (URIRef Absolute) where
+  readField = uriReader
   parseField h n s =
       (Options.option uriReader $
        ( Options.metavar "URI"


### PR DESCRIPTION
This change adds `readField` implementations to the custom `ParseField` instances of the custom data types.

This change is necessary because a `readField` implementation is required as-of the `optparse-generic` release of version `1.2.3`. The `readField` implementation requirement was introduced into `optparse-generic` by [this pull request](https://github.com/Gabriel439/Haskell-Optparse-Generic-Library/pull/44).