### PR TITLE
Switch to nix-paths instead of wrapProgram

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -2,16 +2,16 @@
 , bytestring, concurrentoutput, containers, cryptonite, data-fix
 , deepseq, directory, exceptions, filepath, foldl, hnix
 , http-client, http-types, lens, lens-aeson, lifted-base, memory
-, mtl, neat-interpolation, network, network-uri, optional-args
-, optparse-applicative, optparse-generic, pooled-io, pureMD5
-, scientific, stdenv, tar, tasty, tasty-golden, tasty-hunit
-, tasty-quickcheck, tasty-smallcheck, temporary, text, time
-, transformers, turtle, unordered-containers, uri-bytestring
+, mtl, neat-interpolation, network, network-uri, nix-paths
+, optional-args, optparse-applicative, optparse-generic, pooled-io
+, pureMD5, scientific, stdenv, tar, tasty, tasty-golden
+, tasty-hunit, tasty-quickcheck, tasty-smallcheck, temporary, text
+, time, transformers, turtle, unordered-containers, uri-bytestring
 , vector, wreq, zlib
 }:
 mkDerivation {
   pname = "hocker";
-  version = "0.1.0.0";
+  version = "1.0.3";
   src = ./.;
   isLibrary = true;
   isExecutable = true;
@@ -20,7 +20,7 @@ mkDerivation {
     concurrentoutput containers cryptonite data-fix deepseq directory
     exceptions filepath foldl hnix http-client http-types lens
     lens-aeson lifted-base memory mtl neat-interpolation network
-    network-uri optional-args optparse-applicative optparse-generic
+    network-uri nix-paths optparse-applicative optparse-generic
     pooled-io pureMD5 scientific tar temporary text time transformers
     turtle unordered-containers uri-bytestring vector wreq zlib
   ];
@@ -33,7 +33,7 @@ mkDerivation {
     network network-uri tasty tasty-golden tasty-hunit tasty-quickcheck
     tasty-smallcheck text unordered-containers
   ];
-  homepage = "https://github.com/awakenetworks/hocker#readme";
-  description = "CLI tools and library to interact with a V2 Docker Registry";
+  homepage = "https://github.com/awakesecurity/hocker#readme";
+  description = "Interact with the docker registry and generate nix build instructions";
   license = stdenv.lib.licenses.asl20;
 }

--- a/hocker.cabal
+++ b/hocker.cabal
@@ -100,12 +100,13 @@ library
                 text                 >= 1.2,
                 time                 >= 1.4,
                 transformers         >= 0.4,
-                turtle               >= 1.3,
+                turtle               >= 1.3.0 && < 1.5,
                 unordered-containers >= 0.2,
                 uri-bytestring       >= 0.2,
                 vector               >= 0.11,
                 wreq                 >= 0.4,
-                zlib                 >= 0.6
+                zlib                 >= 0.6,
+                nix-paths            >= 1.0.1 && < 1.1
 
   default-language:    Haskell2010
 

--- a/nix/turtle.nix
+++ b/nix/turtle.nix
@@ -1,20 +1,21 @@
 { mkDerivation, ansi-wl-pprint, async, base, bytestring, clock
-, directory, doctest, foldl, hostname, managed, optional-args
-, optparse-applicative, process, semigroups, stdenv, stm
-, system-fileio, system-filepath, temporary, text, time
-, transformers, unix, unix-compat
+, containers, criterion, directory, doctest, foldl, hostname
+, managed, optional-args, optparse-applicative, process, semigroups
+, stdenv, stm, system-fileio, system-filepath, temporary, text
+, time, transformers, unix, unix-compat
 }:
 mkDerivation {
   pname = "turtle";
-  version = "1.3.6";
-  sha256 = "0fr8p6rnk2lrsgbfh60jlqcjr0nxrh3ywxsj5d4psck0kgyhvg1m";
+  version = "1.4.5";
+  sha256 = "082svk0bcf1vvqrzfmb6r5rridgch0c15423fwcb57cfc8xzm8kx";
   libraryHaskellDepends = [
-    ansi-wl-pprint async base bytestring clock directory foldl hostname
-    managed optional-args optparse-applicative process semigroups stm
-    system-fileio system-filepath temporary text time transformers unix
-    unix-compat
+    ansi-wl-pprint async base bytestring clock containers directory
+    foldl hostname managed optional-args optparse-applicative process
+    semigroups stm system-fileio system-filepath temporary text time
+    transformers unix unix-compat
   ];
   testHaskellDepends = [ base doctest system-filepath temporary ];
+  benchmarkHaskellDepends = [ base criterion text ];
   description = "Shell programming, Haskell-style";
   license = stdenv.lib.licenses.bsd3;
 }

--- a/release.nix
+++ b/release.nix
@@ -13,9 +13,6 @@ let
           turtle =
             haskellPackagesNew.callPackage ./nix/turtle.nix { };
 
-          wreq =
-            haskellPackagesNew.callPackage ./nix/wreq.nix { };
-
           http-client =
             haskellPackagesNew.callPackage ./nix/http-client.nix { };
 
@@ -26,24 +23,7 @@ let
             haskellPackagesNew.callPackage ./nix/Only.nix { };
 
           hocker =
-            pkgs.haskell.lib.overrideCabal
-              ( haskellPackagesNew.callPackage ./default.nix { } )
-              ( oldDerivation: {
-                  testToolDepends =
-                    (oldDerivation.testToolDepends or []) ++[ pkgs.nix ];
-                  buildDepends    =
-                    (oldDerivation.buildDepends or []) ++ [ pkgs.makeWrapper ];
-    
-                  postInstall     =
-                    (oldDerivation.postInstall or "") + ''
-                      wrapProgram $out/bin/hocker-* \
-                        --suffix PATH : ${pkgs.nix}/bin
-
-                      wrapProgram $out/bin/docker2nix \
-                        --suffix PATH : ${pkgs.nix}/bin
-                    '';
-                }
-              );
+            haskellPackagesNew.callPackage ./default.nix { };
         };
       };
     };

--- a/src/Data/Docker/Image/AesonHelpers.hs
+++ b/src/Data/Docker/Image/AesonHelpers.hs
@@ -10,7 +10,6 @@
 module Data.Docker.Image.AesonHelpers where
 
 import           Data.Aeson
-import           Data.Aeson.TH
 
 -- | Produce a default option record with @omitNothingFields@ set to
 -- True by default.

--- a/src/Data/Docker/Nix/FetchDocker.hs
+++ b/src/Data/Docker/Nix/FetchDocker.hs
@@ -83,10 +83,9 @@ generate :: HockerImageMeta -> IO (Either HockerException NExpr)
 generate dim@HockerImageMeta{..} = runExceptT $
   case (manifestJSON ^? key "schemaVersion" . _Integer) of
     Just 2  -> do
-      nixhash      <- Hocker.Lib.findExec "nix-hash"
-      configDigest <- Nix.Lib.toBase32Nix nixhash . Base16Digest $ pluckedConfigDigest
+      configDigest <- Nix.Lib.toBase32Nix . Base16Digest $ pluckedConfigDigest
       layerDigests <- forM pluckedLayerDigests $ \d16 ->
-        (Base16Digest d16,) <$> (Nix.Lib.toBase32Nix nixhash $ Base16Digest d16)
+        (Base16Digest d16,) <$> (Nix.Lib.toBase32Nix $ Base16Digest d16)
 
       ExceptT (pure $ generateFetchDockerExpr dim configDigest layerDigests)
     Just v  ->

--- a/src/Data/Docker/Nix/Lib.hs
+++ b/src/Data/Docker/Nix/Lib.hs
@@ -23,6 +23,8 @@ import qualified Data.Text            as Text
 import           Hocker.Types
 import           Hocker.Types.Exceptions
 
+import qualified Nix.Paths
+
 -- | Convert a 'Base16Digest' to a 'Base32Digest' using the @nix-hash@
 -- utility.
 --
@@ -32,11 +34,12 @@ import           Hocker.Types.Exceptions
 -- instead of re-implementing their algorithm because it's
 -- non-standard and may change, creating a maintenance headache and
 -- surprise behavior.
-toBase32Nix :: (MonadIO m, Except.MonadError HockerException m)
-            => Prelude.FilePath -- ^ Path to the @nix-hash@ executable, see 'Lib.findExec'
-            -> Base16Digest     -- ^ 'Base16Digest' to @base32@ encode
-            -> m Base32Digest
-toBase32Nix nixhash (Base16Digest d16) = do
+toBase32Nix
+  :: (MonadIO m, Except.MonadError HockerException m)
+  => Base16Digest
+  -> m Base32Digest
+toBase32Nix (Base16Digest d16) = do
+  let nixhash       = Nix.Paths.nixHash
   let hockerExc m   = HockerException m Nothing Nothing
   let convertDigest =
         inprocWithErr

--- a/test/Tests/Data/Docker/Nix/FetchDocker.hs
+++ b/test/Tests/Data/Docker/Nix/FetchDocker.hs
@@ -19,6 +19,7 @@ import           Data.ByteString.Lazy.Char8   as C8L
 import           Data.Either                  (either)
 import qualified Data.Text                    as Text
 import           Network.URI
+
 import           Test.Tasty
 import           Test.Tasty.Golden
 import           Test.Tasty.HUnit
@@ -45,9 +46,7 @@ testBase16toBase32 = do
   let b16     = Base16Digest "5c90d4a2d1a8dfffd05ff2dd659923f0ca2d843b5e45d030e17abbcd06a11b5b"
       b32     = Base32Digest "0nqvl43cvfvsw4qd0iay7f22vjph4fcnbpgjbz8gzpx8s6id942w"
 
-  res <- Except.runExceptT $ do
-    nixhash <- Hocker.Lib.findExec "nix-hash"
-    Nix.Lib.toBase32Nix nixhash b16
+  res <- Except.runExceptT (Nix.Lib.toBase32Nix b16)
 
   either
     (assertFailure . show)


### PR DESCRIPTION
This change switches from using `wrapProgram` to supply paths to the Nix executables to the Haskell package `nix-paths`.

There are two motivations:

1. `nix-paths` will throw a compile-time error if it cannot find a
   path for any of the primary Nix executables (Nix is a dependency of
   this package inside of nixpkgs too so we don't need to worry about
   it anymore)

2. `wrapProgram` now throws an error if globbed file paths are given as input; which could easily be worked around but it served as impetus to solve this "The Right Way"