### PR TITLE
Refactor supporting Nix code and pin to nixpkgs-17.09 latest

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -11,7 +11,7 @@
 }:
 mkDerivation {
   pname = "hocker";
-  version = "1.0.3";
+  version = "1.0.4";
   src = ./.;
   isLibrary = true;
   isExecutable = true;

--- a/hocker.cabal
+++ b/hocker.cabal
@@ -65,7 +65,7 @@ library
                   Network.Wreq.ErrorHandling
   build-depends:
                 base                 >= 4.9 && < 5,
-                aeson                >= 0.9.0.1,
+                aeson                >= 1.0.0.0,
                 aeson-pretty         >= 0.8,
                 ansi-wl-pprint       >= 0.6.7.3,
                 async                >= 2.0.0.0 && < 2.2,

--- a/nix/17_09.nix
+++ b/nix/17_09.nix
@@ -1,0 +1,9 @@
+let
+  fetchNixpkgs = import ./fetchNixpkgs.nix;
+
+in
+  fetchNixpkgs {
+     rev          = "3389f23412877913b9d22a58dfb241684653d7e9";
+     sha256       = "1zf05a90d29bpl7j56y20r3kmrl4xkvg7gsfi55n6bb2r0xp2ma5";
+     outputSha256 = "0wgm7sk9fca38a50hrsqwz6q79z35gqgb9nw80xz7pfdr4jy9pf8";
+  }

--- a/nix/fetchNixpkgs.nix
+++ b/nix/fetchNixpkgs.nix
@@ -1,0 +1,56 @@
+{ rev                             # The Git revision of nixpkgs to fetch
+, sha256                          # The SHA256 of the downloaded data
+, outputSha256 ? null             # The SHA256 output hash
+, system ? builtins.currentSystem # This is overridable if necessary
+}:
+
+with {
+  ifThenElse = { bool, thenValue, elseValue }: (
+    if bool then thenValue else elseValue);
+};
+
+ifThenElse {
+  bool = (0 <= builtins.compareVersions builtins.nixVersion "1.12");
+
+  # In Nix 1.12, we can just give a `sha256` to `builtins.fetchTarball`.
+  thenValue = (
+    builtins.fetchTarball {
+      url = "https://github.com/NixOS/nixpkgs/archive/${rev}.tar.gz";
+      inherit sha256;
+    });
+
+  # This hack should at least work for Nix 1.11
+  elseValue = (
+    (rec {
+      tarball = import <nix/fetchurl.nix> {
+        url = "https://github.com/NixOS/nixpkgs/archive/${rev}.tar.gz";
+        inherit sha256;
+      };
+
+      builtin-paths = import <nix/config.nix>;
+      
+      script = builtins.toFile "nixpkgs-unpacker" ''
+        "$coreutils/mkdir" "$out"
+        cd "$out"
+        "$gzip" --decompress < "$tarball" | "$tar" -x --strip-components=1
+      '';
+
+      nixpkgs = builtins.derivation ({
+        name = "nixpkgs-${builtins.substring 0 6 rev}";
+
+        builder = builtins.storePath builtin-paths.shell;
+
+        args = [ script ];
+
+        inherit tarball system;
+
+        tar       = builtins.storePath builtin-paths.tar;
+        gzip      = builtins.storePath builtin-paths.gzip;
+        coreutils = builtins.storePath builtin-paths.coreutils;
+      } // (if null == outputSha256 then { } else {
+        outputHashMode = "recursive";
+        outputHashAlgo = "sha256";
+        outputHash = outputSha256;
+      }));
+    }).nixpkgs);
+}

--- a/nix/nix-paths.nix
+++ b/nix/nix-paths.nix
@@ -1,0 +1,11 @@
+{ mkDerivation, base, nix, process, stdenv }:
+mkDerivation {
+  pname = "nix-paths";
+  version = "1.0.1";
+  sha256 = "1y09wl1ihxmc9p926g595f70pdcsx78r3q5n5rna23lpq8xicdxb";
+  libraryHaskellDepends = [ base process ];
+  libraryToolDepends = [ nix ];
+  homepage = "https://github.com/peti/nix-paths";
+  description = "Knowledge of Nix's installation directories";
+  license = stdenv.lib.licenses.bsd3;
+}

--- a/release.nix
+++ b/release.nix
@@ -1,10 +1,15 @@
 let
-  config = { allowUnfree = true;
-    packageOverrides = pkgs: {
-      haskellPackages = pkgs.haskellPackages.override {
+
+  config = { allowUnfree = true; };
+
+  overlays = [
+    (newPkgs: oldPkgs: {
+
+      haskellPackages = oldPkgs.haskellPackages.override {
         overrides = haskellPackagesNew: haskellPackagesOld: {
+
           optparse-applicative =
-            pkgs.haskell.lib.dontCheck
+            newPkgs.haskell.lib.dontCheck
               (haskellPackagesNew.callPackage ./nix/optparse-applicative.nix { });
 
           optparse-generic =
@@ -13,22 +18,20 @@ let
           turtle =
             haskellPackagesNew.callPackage ./nix/turtle.nix { };
 
-          http-client =
-            haskellPackagesNew.callPackage ./nix/http-client.nix { };
-
-          http-client-tls =
-            haskellPackagesNew.callPackage ./nix/http-client-tls.nix { };
-
-          Only =
-            haskellPackagesNew.callPackage ./nix/Only.nix { };
+          nix-paths =
+            haskellPackagesNew.callPackage ./nix/nix-paths.nix { };
 
           hocker =
             haskellPackagesNew.callPackage ./default.nix { };
         };
       };
-    };
-  };
 
-  pkgs = import <nixpkgs> { inherit config; };
+    })
+  ];
+
+  nixpkgs = import ./nix/17_09.nix;
+
+  pkgs = import nixpkgs { inherit config overlays; };
+
 in
   { inherit (pkgs.haskellPackages) hocker; }

--- a/src/Data/Docker/Image/AesonHelpers.hs
+++ b/src/Data/Docker/Image/AesonHelpers.hs
@@ -9,7 +9,7 @@
 
 module Data.Docker.Image.AesonHelpers where
 
-import           Data.Aeson
+import           Data.Aeson.Types
 
 -- | Produce a default option record with @omitNothingFields@ set to
 -- True by default.


### PR DESCRIPTION
This change also fixes a compile error related to a datatype that is no longer re-exported by the `Data.Aeson` module in `aeson-1.1.2.0` (supplied by `nixpkgs-17.09`), requiring an import of the `Data.Aeson.Types` module and a change to the lower bound of `1.0.0.0` on the Aeson library.