### PR TITLE
Explicitly specify the golden test data

### DIFF
--- a/hocker.cabal
+++ b/hocker.cabal
@@ -36,8 +36,9 @@ extra-source-files:
   README.md
   CHANGELOG.md
 
-data-dir:
-  test/data
+data-files:
+  test/data/golden-debian:jessie.nix
+  test/data/manifest-debian:jessie.json
 
 source-repository head
   type:     git


### PR DESCRIPTION
... because `data-dir` was incorrect and doesn't work, breaking the tests.