### PR TITLE
Fix `hocker-image`

### DIFF
--- a/src/Network/Wreq/Docker/Image.hs
+++ b/src/Network/Wreq/Docker/Image.hs
@@ -48,7 +48,7 @@ fetchImage :: HockerMeta -> IO (Either HockerException Text)
 fetchImage =
   runHocker $ ask >>= \HockerMeta{..} -> do
     imageOutDir  <- Hocker.Lib.requirePath outDir
-    manifest     <- fetchManifest >>= checkResponseIntegrity'
+    manifest     <- fetchManifest
     configDigest <- getConfigDigest $ manifest ^. Wreq.responseBody
 
     -- TODO: use Managed


### PR DESCRIPTION
This PR introduces two changes that fix `hocker-image`:

- as done in 63129b1, we should not check the integrity of the response when asking for the manifest due to https://github.com/docker/distribution/issues/2395
- serialization of the docker registry URI was incorrect, I think this regression was introduced into the code before we open sourced