### PR TITLE
1.0.4 -> 1.0.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 1.0.5
+### Fixed
+- Add the golden test data to the source distribution by using `data-files`
+  instead of the incorrect `data-dir`, this fixes the problem of `cabal test`
+  failing when run outside of the repository root on an unpacked tarball of the
+  source distribution from Hackage
+- The failing response integrity check in `hocker-image` by removing the check,
+  the fix and its rationale are exactly the same as applied to `hocker-config`
+  and `hocker-layer` in the `1.0.2` release
+- Incorrect serialization of the registry URI in the `fetchImage` function,
+  resulting in a malformed repository string that `docker load` would fail to
+  import
+
 ## 1.0.4
 ### Changed
 - Switched to the `nix-paths` library which provides compile-time constants for

--- a/default.nix
+++ b/default.nix
@@ -11,7 +11,7 @@
 }:
 mkDerivation {
   pname = "hocker";
-  version = "1.0.4";
+  version = "1.0.5";
   src = ./.;
   isLibrary = true;
   isExecutable = true;

--- a/hocker.cabal
+++ b/hocker.cabal
@@ -1,5 +1,5 @@
 name:                hocker
-version:             1.0.4
+version:             1.0.5
 synopsis:            Interact with the docker registry and generate nix build instructions
 homepage:            https://github.com/awakesecurity/hocker#readme
 Bug-Reports:         https://github.com/awakesecurity/hocker/issues


### PR DESCRIPTION
This change bumps the patch version of `hocker` for fixes included in the following commits:

- 19c51d0
- ef9e6bd