### PR TITLE
`outputSha256` should be the hash given to builtins.fetchTarball

### DIFF
--- a/nix/fetchNixpkgs.nix
+++ b/nix/fetchNixpkgs.nix
@@ -16,7 +16,7 @@ ifThenElse {
   thenValue = (
     builtins.fetchTarball {
       url = "https://github.com/NixOS/nixpkgs/archive/${rev}.tar.gz";
-      inherit sha256;
+      sha256 = outputSha256;
     });
 
   # This hack should at least work for Nix 1.11


### PR DESCRIPTION
... since it expects the fixed-output hash, not the intermediate hash that is used by the Nix 1.11.x logic.

Fixes #38.