### PR TITLE
Relax upper bound on `turtle` from `< 1.5` to `< 1.6`

### DIFF
--- a/hocker.cabal
+++ b/hocker.cabal
@@ -101,7 +101,7 @@ library
                 text                 >= 1.2,
                 time                 >= 1.4,
                 transformers         >= 0.4,
-                turtle               >= 1.3.0 && < 1.5,
+                turtle               >= 1.3.0 && < 1.6,
                 unordered-containers >= 0.2,
                 uri-bytestring       >= 0.2,
                 vector               >= 0.11,


### PR DESCRIPTION
Fixes #37.