### PR TITLE
Support newer versions of hnix...

### DIFF
--- a/hocker.cabal
+++ b/hocker.cabal
@@ -86,6 +86,7 @@ library
                 lens                 >= 4.0,
                 lens-aeson           >= 1.0,
                 lifted-base          >= 0.2.3.8,
+                megaparsec           >= 6.0.0,
                 memory               >= 0.11,
                 mtl                  >= 2.2,
                 neat-interpolation   >= 0.3.2,
@@ -239,7 +240,8 @@ test-suite hocker-tests
                 tasty-quickcheck     >= 0.8,
                 tasty-smallcheck     >= 0.8,
                 text                 >= 1.2,
-                unordered-containers >= 0.2
+                unordered-containers >= 0.2,
+                word8                >= 0.1.0
 
 
   ghc-options:         -threaded -rtsopts -with-rtsopts=-N

--- a/src/Hocker/Lib.hs
+++ b/src/Hocker/Lib.hs
@@ -28,7 +28,7 @@ import           Data.Aeson.Lens
 import qualified Data.ByteString.Char8        as C8
 import           Data.ByteString.Lazy.Char8   as C8L
 import           Data.Coerce
-import           Data.Monoid
+import           Data.Semigroup               ((<>))
 import           Data.Text                    (Text)
 import qualified Data.Text                    as Text
 import           Data.Text.Encoding           (encodeUtf8)

--- a/src/Hocker/Types.hs
+++ b/src/Hocker/Types.hs
@@ -31,7 +31,7 @@ import           Control.Monad.Reader.Class
 import qualified Crypto.Hash                as Hash
 import qualified Data.ByteString.Lazy
 import           Data.Char                  (toUpper)
-import           Data.Monoid
+import           Data.Semigroup             ((<>))
 import           Data.Text                  (Text)
 import qualified Data.Text                  as Text
 import qualified Network.Wreq               as Wreq

--- a/src/Hocker/Types/Exceptions.hs
+++ b/src/Hocker/Types/Exceptions.hs
@@ -19,7 +19,7 @@ module Hocker.Types.Exceptions where
 
 import           Control.DeepSeq
 import           Control.Exception
-import           Data.Monoid
+import           Data.Semigroup     ((<>))
 import           GHC.Generics
 
 data HockerException = HockerException

--- a/src/Hocker/Types/Hash.hs
+++ b/src/Hocker/Types/Hash.hs
@@ -17,7 +17,7 @@ import qualified Crypto.Hash             as Hash
 import qualified Data.ByteArray          as BA
 import qualified Data.ByteArray.Encoding as BA
 import qualified Data.ByteString.Char8   as C8
-import           Data.Monoid
+import           Data.Semigroup          ((<>))
 import qualified Data.Text
 import qualified Options.Applicative     as Options
 import           Options.Generic

--- a/src/Hocker/Types/ImageName.hs
+++ b/src/Hocker/Types/ImageName.hs
@@ -15,7 +15,7 @@
 module Hocker.Types.ImageName where
 
 import           Control.DeepSeq
-import           Data.Monoid
+import           Data.Semigroup      ((<>))
 import qualified Options.Applicative as Options
 import           Options.Generic
 

--- a/src/Hocker/Types/ImageTag.hs
+++ b/src/Hocker/Types/ImageTag.hs
@@ -15,7 +15,7 @@
 module Hocker.Types.ImageTag where
 
 import           Control.DeepSeq
-import           Data.Monoid
+import           Data.Semigroup      ((<>))
 import qualified Options.Applicative as Options
 import           Options.Generic
 

--- a/src/Hocker/Types/URI.hs
+++ b/src/Hocker/Types/URI.hs
@@ -16,7 +16,7 @@ module Hocker.Types.URI where
 
 import           Control.Lens
 import qualified Data.ByteString.Char8       as C8
-import           Data.Monoid
+import           Data.Semigroup              ((<>))
 import qualified Data.Text                   as Text
 import qualified Options.Applicative         as Options
 import           Options.Applicative.Builder

--- a/src/Network/Wreq/Docker/Image.hs
+++ b/src/Network/Wreq/Docker/Image.hs
@@ -25,7 +25,7 @@ import           Data.ByteString.Lazy.Char8    as C8L
 import           Data.Coerce
 import           Data.Either
 import           Data.HashSet                  as Set
-import           Data.Monoid
+import           Data.Semigroup                ((<>))
 import           Data.Text                     (Text)
 import qualified Data.Text                     as Text
 import           Data.Text.Encoding            (decodeUtf8')

--- a/src/Network/Wreq/Docker/Image/Lib.hs
+++ b/src/Network/Wreq/Docker/Image/Lib.hs
@@ -24,7 +24,7 @@ import           Control.Monad.Reader
 import qualified Data.ByteString.Lazy.Char8        as C8L
 import           Data.Coerce
 import qualified Data.HashMap.Strict               as HashMap
-import           Data.Monoid
+import           Data.Semigroup                    ((<>))
 import qualified Data.Text                         as Text
 import qualified Network.Wreq                      as Wreq
 import qualified System.Directory                  as Directory

--- a/src/Network/Wreq/Docker/Registry.hs
+++ b/src/Network/Wreq/Docker/Registry.hs
@@ -27,7 +27,6 @@ module Network.Wreq.Docker.Registry where
 import           Control.Lens
 import qualified Control.Monad.Except       as Except
 import           Control.Monad.Reader
-import           Data.Monoid
 import qualified Crypto.Hash                as Hash
 import           Data.Aeson.Lens
 import           Data.ByteString.Lazy.Char8 as C8L
@@ -35,6 +34,7 @@ import qualified Data.ByteString.Char8      as C8
 import           Data.Text.Encoding         (decodeUtf8, encodeUtf8)
 import           URI.ByteString
 import           NeatInterpolation
+import           Data.Semigroup             ((<>))
 import qualified Data.Text                  as Text
 import qualified Network.Wreq               as Wreq
 import           System.Directory
@@ -64,7 +64,7 @@ defaultRegistry = URI
 --
 -- If 'Credentials' is either 'BearerToken' or 'Basic' then produce a
 -- 'Wreq.Auth' value for that type of credential.
--- 
+--
 -- If @Nothing@ is provided _and_ the provided 'RegistryURI' matches
 -- the default registry, make a request to
 -- @https://auth.docker.io/token@ for a temporary pull-only bearer
@@ -131,7 +131,7 @@ fetchImageConfig (showSHA -> digest) = ask >>= \HockerMeta{..} ->
     mkURL (ImageName n) r = C8.unpack (serializeURIRef' $ Hocker.Lib.joinURIPath [n, "blobs", digest] r)
 
 -- | Retrieve a compressed layer blob by its hash digest.
--- 
+--
 -- TODO: take advantage of registry's support for the Range header so
 -- we can stream downloads.
 fetchLayer :: Layer -> Hocker RspBS

--- a/src/Network/Wreq/ErrorHandling.hs
+++ b/src/Network/Wreq/ErrorHandling.hs
@@ -21,7 +21,7 @@ import           Control.Exception.Lifted  as Lifted
 import           Control.Lens
 import           Control.Monad.Except
 import           Data.ByteString.Char8     as C8
-import           Data.Monoid
+import           Data.Semigroup            ((<>))
 import           Network.HTTP.Client
 import           Network.HTTP.Types.Status
 


### PR DESCRIPTION
...and avoid warnings on base library versions
in which Semigroup is a superclass of Monoid.

NOTE: This PR conflicts to some extent with #42 .
I would just use #42 except that it requires
megaparsec 7, and currently an important
application must use megaparsec 6.5.