### PR TITLE
Be compatible with foldl-1.4.5.

### DIFF
--- a/src/Data/Docker/Nix/Lib.hs
+++ b/src/Data/Docker/Nix/Lib.hs
@@ -15,7 +15,7 @@
 
 module Data.Docker.Nix.Lib where
 
-import           Control.Foldl        as Foldl
+import qualified Control.Foldl        as Foldl
 import           Turtle
 import           Control.Monad.Except as Except
 import qualified Data.Text            as Text


### PR DESCRIPTION
Starting with v1.4.5, foldl defines an "either"
that gets confused with the usual Prelude function
unless one uses a qualified import.