### PR TITLE
Bump `hnix` dependency to a min-bound of `0.6.0`

### DIFF
--- a/hocker.cabal
+++ b/hocker.cabal
@@ -79,7 +79,7 @@ library
                 exceptions           >= 0.8,
                 filepath             >= 1.4,
                 foldl                >= 1.0,
-                hnix                 >= 0.5.2,
+                hnix                 >= 0.6.0,
                 http-client          >= 0.4,
                 http-types           >= 0.9.1,
                 lens                 >= 4.0,


### PR DESCRIPTION
Fixes #47.