### PR TITLE
Use `optparse-generic` 1.4.4

### DIFF
--- a/hocker.cabal
+++ b/hocker.cabal
@@ -92,7 +92,7 @@ library
                 network              >= 2.6,
                 network-uri          >= 2.6,
                 optparse-applicative >= 0.13,
-                optparse-generic     >= 1.2.0,
+                optparse-generic     >= 1.4.0,
                 prettyprinter        >= 1.1.1,
                 pooled-io            >= 0.0.2,
                 pureMD5              >= 2.1,

--- a/nix/optparse-generic.nix
+++ b/nix/optparse-generic.nix
@@ -1,0 +1,16 @@
+{ mkDerivation, base, bytestring, lib, Only, optparse-applicative
+, system-filepath, text, time, transformers, void
+}:
+mkDerivation {
+  pname = "optparse-generic";
+  version = "1.4.4";
+  sha256 = "e44853c0a3def2556cec31337db411d6404d7f81d505662f8ebac68e119bc077";
+  revision = "1";
+  editedCabalFile = "14vbfbl2va3s2pa4qjyyny1i15s2iw9993ld5b0qsqdv1z6nfjz1";
+  libraryHaskellDepends = [
+    base bytestring Only optparse-applicative system-filepath text time
+    transformers void
+  ];
+  description = "Auto-generate a command-line parser for your datatype";
+  license = lib.licenses.bsd3;
+}

--- a/release.nix
+++ b/release.nix
@@ -75,6 +75,7 @@ let
                         "lifted-async"
                         "memory"
                         "microstache"
+                        "optparse-generic"
                         "prettyprinter"
                         "quickcheck-instances"
                         "regex-base"

--- a/src/Hocker/Types.hs
+++ b/src/Hocker/Types.hs
@@ -158,7 +158,7 @@ data Credentials = Basic Username Password | BearerToken Text
 
 instance ParseField Credentials where
   readField = Options.readerError "Internal, fatal error: unexpected use of readField"
-  parseField _ _ _ = (Basic <$> parseUsername <*> parsePassword) <|> (BearerToken <$> parseToken)
+  parseField _help _long _short _value = (Basic <$> parseUsername <*> parsePassword) <|> (BearerToken <$> parseToken)
     where
       parseUsername = Text.pack <$>
         (Options.option Options.str $

--- a/src/Hocker/Types/Hash.hs
+++ b/src/Hocker/Types/Hash.hs
@@ -30,12 +30,12 @@ readSHA256 = either (const Nothing) Hash.digestFromByteString . toBytes
 
 instance ParseField (Hash.Digest Hash.SHA256) where
   readField = Options.maybeReader (readSHA256 . C8.pack)
-  parseField h _ _ =
+  parseField help _long _short _value =
       (Options.option (Options.maybeReader (readSHA256 . C8.pack)) $
        ( Options.metavar "SHA256"
        <> Options.short 'l'
        <> Options.long "layer"
-       <> maybe mempty (Options.help . Data.Text.unpack) h
+       <> maybe mempty (Options.help . Data.Text.unpack) help
        )
       )
 

--- a/src/Hocker/Types/ImageName.hs
+++ b/src/Hocker/Types/ImageName.hs
@@ -24,7 +24,7 @@ newtype ImageName = ImageName { unImageName :: String }
 
 instance ParseField ImageName where
   readField = ImageName <$> Options.str
-  parseField _ _ _ =
+  parseField _help _long _short _value =
     ImageName <$>
       (Options.argument Options.str $
        ( Options.metavar "IMAGE-NAME"

--- a/src/Hocker/Types/ImageTag.hs
+++ b/src/Hocker/Types/ImageTag.hs
@@ -24,7 +24,7 @@ newtype ImageTag = ImageTag { unImageTag :: String }
 
 instance ParseField ImageTag where
   readField = ImageTag <$> Options.str
-  parseField _ _ _ =
+  parseField _help _long _short _value =
     ImageTag <$>
       (Options.argument Options.str $
        ( Options.metavar "IMAGE-TAG"

--- a/src/Hocker/Types/URI.hs
+++ b/src/Hocker/Types/URI.hs
@@ -32,12 +32,12 @@ uriReader = Options.eitherReader parseURIArg
 
 instance ParseField (URIRef Absolute) where
   readField = uriReader
-  parseField h n s =
+  parseField help long short _value =
       (Options.option uriReader $
        ( Options.metavar "URI"
-       <> foldMap (Options.long  . Text.unpack) n
-       <> foldMap Options.short s
-       <> foldMap (Options.help  . Text.unpack) h
+       <> foldMap (Options.long  . Text.unpack) long
+       <> foldMap Options.short short
+       <> foldMap (Options.help  . Text.unpack) help
        )
       )
 


### PR DESCRIPTION
I don't know whether `hocker` will instantiate of compile successfully after this change, because I don't have time to wait for tons of stuff to substitute and build, and we don't have CI...

I did confirm that this change compiles when using a recent revision of Nixpkgs, which includes a newer GHC and Haskell package set (I'll submit another pull request for that upgrade), but I can't confirm it will work with the current Nix code.