### PR TITLE
docker2nix: `inprocWithErr` -> `procStrictWithErr`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,11 +10,11 @@ jobs:
     steps:
       - uses: actions/checkout@v3.0.2
         name: Checkout
-      - uses: cachix/install-nix-action@v17
+      - uses: cachix/install-nix-action@v20
         name: Install Nix
         with:
           nix_path: nixpkgs=./nix/pkgs.nix
-      - uses: cachix/cachix-action@v10
+      - uses: cachix/cachix-action@v12
         name: Set up Cachix
         with:
           name: awakesecurity
@@ -27,11 +27,11 @@ jobs:
     steps:
       - uses: actions/checkout@v3.0.2
         name: Checkout
-      - uses: cachix/install-nix-action@v17
+      - uses: cachix/install-nix-action@v20
         name: Install Nix
         with:
           nix_path: nixpkgs=./nix/pkgs.nix
-      - uses: cachix/cachix-action@v10
+      - uses: cachix/cachix-action@v12
         name: Set up Cachix
         with:
           name: awakesecurity

--- a/src/Data/Docker/Nix/FetchDocker.hs
+++ b/src/Data/Docker/Nix/FetchDocker.hs
@@ -24,7 +24,6 @@ import qualified Data.Bifunctor               as Bifunctor
 import           Data.Coerce
 import           Data.Fix
 import           Data.Maybe
-import           Data.Semigroup               ((<>))
 import           Data.Text                    (Text)
 import qualified Data.Text                    as Text
 import           Data.Text.Encoding           (decodeUtf8')
@@ -40,7 +39,7 @@ import           Network.Wreq.Docker.Registry (pluckLayersFrom)
 import           Hocker.Types
 import           Hocker.Types.Exceptions
 import           Hocker.Types.ImageTag
-import           Text.Megaparsec.Pos          (Pos, mkPos)
+import           Text.Megaparsec.Pos          (Pos)
 
 -- | @hnix-0.5.0:inherit@ requires a source location as its final argument.
 inheritAdapter :: FilePath -> Pos -> Pos -> [NKeyName e] -> Binding e

--- a/src/Data/Docker/Nix/Lib.hs
+++ b/src/Data/Docker/Nix/Lib.hs
@@ -58,7 +58,7 @@ toBase32Nix (Base16Digest d16) = do
            "nothing was returned by `nix-hash', not even an error"
            Nothing
             Nothing)
-    Just (ExitFailure _, errorText, _) ->
+    Just (ExitFailure _, _, errorText) ->
       throwError (hockerExc (Text.unpack errorText))
-    Just (ExitSuccess, _, resultText) ->
+    Just (ExitSuccess, resultText, _) ->
       return (Base32Digest resultText)

--- a/src/Data/Docker/Nix/Lib.hs
+++ b/src/Data/Docker/Nix/Lib.hs
@@ -2,7 +2,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards   #-}
 {-# LANGUAGE TupleSections     #-}
-{-# LANGUAGE FlexibleContexts     #-}
+{-# LANGUAGE FlexibleContexts  #-}
 
 -----------------------------------------------------------------------------
 -- |
@@ -42,7 +42,7 @@ toBase32Nix (Base16Digest d16) = do
   let nixhash       = Nix.Paths.nixHash
   let hockerExc m   = HockerException m Nothing Nothing
   let convertDigest =
-        inprocWithErr
+        procStrictWithErr
           (Text.pack nixhash)
           [ "--type"
           , "sha256"
@@ -58,8 +58,7 @@ toBase32Nix (Base16Digest d16) = do
            "nothing was returned by `nix-hash', not even an error"
            Nothing
             Nothing)
-    Just result ->
-      either
-       (throwError . hockerExc . Text.unpack . lineToText)
-       (return . Base32Digest . lineToText)
-       result
+    Just (ExitFailure _, errorText, _) ->
+      throwError (hockerExc (Text.unpack errorText))
+    Just (ExitSuccess, _, resultText) ->
+      return (Base32Digest resultText)

--- a/src/Data/Docker/Nix/Lib.hs
+++ b/src/Data/Docker/Nix/Lib.hs
@@ -61,4 +61,4 @@ toBase32Nix (Base16Digest d16) = do
     Just (ExitFailure _, _, errorText) ->
       throwError (hockerExc (Text.unpack errorText))
     Just (ExitSuccess, resultText, _) ->
-      return (Base32Digest resultText)
+      return (Base32Digest (Text.strip resultText))

--- a/src/Hocker/Lib.hs
+++ b/src/Hocker/Lib.hs
@@ -28,7 +28,6 @@ import           Data.Aeson.Lens
 import qualified Data.ByteString.Char8        as C8
 import           Data.ByteString.Lazy.Char8   as C8L
 import           Data.Coerce
-import           Data.Semigroup               ((<>))
 import           Data.Text                    (Text)
 import qualified Data.Text                    as Text
 import           Data.Text.Prettyprint.Doc    (LayoutOptions(..),

--- a/src/Hocker/Lib.hs
+++ b/src/Hocker/Lib.hs
@@ -30,10 +30,10 @@ import           Data.ByteString.Lazy.Char8   as C8L
 import           Data.Coerce
 import           Data.Text                    (Text)
 import qualified Data.Text                    as Text
-import           Data.Text.Prettyprint.Doc    (LayoutOptions(..),
+import           Prettyprinter                (LayoutOptions(..),
                                                PageWidth(..), SimpleDocStream)
-import qualified Data.Text.Prettyprint.Doc
-import qualified Data.Text.Prettyprint.Doc.Render.Text
+import qualified Prettyprinter
+import qualified Prettyprinter.Render.Text
 import           Data.Text.Encoding           (encodeUtf8)
 import qualified Network.Wreq                 as Wreq
 import           Nix.Expr                     (NExpr)
@@ -172,7 +172,7 @@ splitRepository (ImageName (Text.pack -> n)) = over _2 Text.tail $ Text.break (=
 -- | Given a nix expression AST, produce a pretty printer document.
 renderNixExpr :: NExpr -> SimpleDocStream ann
 renderNixExpr =
-    Data.Text.Prettyprint.Doc.layoutSmart layoutOptions . prettyNix
+    Prettyprinter.layoutSmart layoutOptions . prettyNix
   where
     layoutOptions = LayoutOptions { layoutPageWidth = AvailablePerLine 120 0.4 }
 
@@ -180,7 +180,7 @@ renderNixExpr =
 -- printing renderer.
 pprintNixExpr :: NExpr -> IO ()
 pprintNixExpr expr =
-    Data.Text.Prettyprint.Doc.Render.Text.renderIO System.IO.stdout stream
+    Prettyprinter.Render.Text.renderIO System.IO.stdout stream
   where
     stream = renderNixExpr expr
 

--- a/src/Hocker/Types.hs
+++ b/src/Hocker/Types.hs
@@ -31,8 +31,6 @@ import           Control.Monad.Reader.Class
 import qualified Crypto.Hash                as Hash
 import qualified Data.ByteString.Lazy
 import           Data.Char                  (toUpper)
-import           Data.Semigroup             ((<>))
-import           Data.Text                  (Text)
 import qualified Data.Text                  as Text
 import qualified Network.Wreq               as Wreq
 import           Network.Wreq.ErrorHandling

--- a/src/Hocker/Types/Exceptions.hs
+++ b/src/Hocker/Types/Exceptions.hs
@@ -19,7 +19,6 @@ module Hocker.Types.Exceptions where
 
 import           Control.DeepSeq
 import           Control.Exception
-import           Data.Semigroup     ((<>))
 import           GHC.Generics
 
 data HockerException = HockerException

--- a/src/Hocker/Types/Hash.hs
+++ b/src/Hocker/Types/Hash.hs
@@ -17,7 +17,6 @@ import qualified Crypto.Hash             as Hash
 import qualified Data.ByteArray          as BA
 import qualified Data.ByteArray.Encoding as BA
 import qualified Data.ByteString.Char8   as C8
-import           Data.Semigroup          ((<>))
 import qualified Data.Text
 import qualified Options.Applicative     as Options
 import           Options.Generic

--- a/src/Hocker/Types/ImageName.hs
+++ b/src/Hocker/Types/ImageName.hs
@@ -15,7 +15,6 @@
 module Hocker.Types.ImageName where
 
 import           Control.DeepSeq
-import           Data.Semigroup      ((<>))
 import qualified Options.Applicative as Options
 import           Options.Generic
 

--- a/src/Hocker/Types/ImageTag.hs
+++ b/src/Hocker/Types/ImageTag.hs
@@ -15,7 +15,6 @@
 module Hocker.Types.ImageTag where
 
 import           Control.DeepSeq
-import           Data.Semigroup      ((<>))
 import qualified Options.Applicative as Options
 import           Options.Generic
 

--- a/src/Hocker/Types/URI.hs
+++ b/src/Hocker/Types/URI.hs
@@ -16,7 +16,6 @@ module Hocker.Types.URI where
 
 import           Control.Lens
 import qualified Data.ByteString.Char8       as C8
-import           Data.Semigroup              ((<>))
 import qualified Data.Text                   as Text
 import qualified Options.Applicative         as Options
 import           Options.Applicative.Builder
@@ -32,12 +31,12 @@ uriReader = Options.eitherReader parseURIArg
 
 instance ParseField (URIRef Absolute) where
   readField = uriReader
-  parseField help long short _value =
+  parseField helpMsg longStr shortStr _value =
       (Options.option uriReader $
        ( Options.metavar "URI"
-       <> foldMap (Options.long  . Text.unpack) long
-       <> foldMap Options.short short
-       <> foldMap (Options.help  . Text.unpack) help
+       <> foldMap (Options.long  . Text.unpack) longStr
+       <> foldMap Options.short shortStr
+       <> foldMap (Options.help  . Text.unpack) helpMsg
        )
       )
 

--- a/src/Network/Wreq/Docker/Image.hs
+++ b/src/Network/Wreq/Docker/Image.hs
@@ -25,7 +25,6 @@ import           Data.ByteString.Lazy.Char8    as C8L
 import           Data.Coerce
 import           Data.Either
 import           Data.HashSet                  as Set
-import           Data.Semigroup                ((<>))
 import           Data.Text                     (Text)
 import qualified Data.Text                     as Text
 import           Data.Text.Encoding            (decodeUtf8')
@@ -129,7 +128,7 @@ fetchLayer =
 -- docker registry.
 fetchConfig :: HockerMeta -> IO (Either HockerException C8L.ByteString)
 fetchConfig =
-  runHocker $ ask >>= \HockerMeta{..} -> do
+  runHocker $ ask >>= \HockerMeta{} -> do
     configDigest <-
       fetchManifest
         >>= getConfigDigest . view Wreq.responseBody

--- a/src/Network/Wreq/Docker/Image/Lib.hs
+++ b/src/Network/Wreq/Docker/Image/Lib.hs
@@ -24,7 +24,6 @@ import           Control.Monad.Reader
 import qualified Data.ByteString.Lazy.Char8        as C8L
 import           Data.Coerce
 import qualified Data.HashMap.Strict               as HashMap
-import           Data.Semigroup                    ((<>))
 import qualified Data.Text                         as Text
 import qualified Network.Wreq                      as Wreq
 import qualified System.Directory                  as Directory

--- a/src/Network/Wreq/Docker/Registry.hs
+++ b/src/Network/Wreq/Docker/Registry.hs
@@ -34,7 +34,6 @@ import qualified Data.ByteString.Char8      as C8
 import           Data.Text.Encoding         (decodeUtf8, encodeUtf8)
 import           URI.ByteString
 import           NeatInterpolation
-import           Data.Semigroup             ((<>))
 import qualified Data.Text                  as Text
 import qualified Network.Wreq               as Wreq
 import           System.Directory

--- a/src/Network/Wreq/ErrorHandling.hs
+++ b/src/Network/Wreq/ErrorHandling.hs
@@ -21,7 +21,6 @@ import           Control.Exception.Lifted  as Lifted
 import           Control.Lens
 import           Control.Monad.Except
 import           Data.ByteString.Char8     as C8
-import           Data.Semigroup            ((<>))
 import           Network.HTTP.Client
 import           Network.HTTP.Types.Status
 

--- a/test/Tests/Data/Docker/Nix/FetchDocker.hs
+++ b/test/Tests/Data/Docker/Nix/FetchDocker.hs
@@ -19,7 +19,7 @@ import           Data.ByteString              as BS
 import           Data.ByteString.Lazy.Char8   as C8L
 import           Data.Either                  (either)
 import qualified Data.Text                    as Text
-import qualified Data.Text.Prettyprint.Doc.Render.String
+import qualified Prettyprint.Render.String
 import           Data.Word8                   as W8
 import           Network.URI
 
@@ -105,7 +105,7 @@ generateFetchDockerNix = do
       , altImageName   = Nothing
       }
 
-  let display = Data.Text.Prettyprint.Doc.Render.String.renderString
+  let display = Prettyprint.Render.String.renderString
 
   either
     (Hocker.Lib.die . Text.pack . show)

--- a/test/Tests/Data/Docker/Nix/FetchDocker.hs
+++ b/test/Tests/Data/Docker/Nix/FetchDocker.hs
@@ -19,7 +19,7 @@ import           Data.ByteString              as BS
 import           Data.ByteString.Lazy.Char8   as C8L
 import           Data.Either                  (either)
 import qualified Data.Text                    as Text
-import qualified Prettyprint.Render.String
+import qualified Prettyprinter.Render.String
 import           Data.Word8                   as W8
 import           Network.URI
 
@@ -105,7 +105,7 @@ generateFetchDockerNix = do
       , altImageName   = Nothing
       }
 
-  let display = Prettyprint.Render.String.renderString
+  let display = Prettyprinter.Render.String.renderString
 
   either
     (Hocker.Lib.die . Text.pack . show)


### PR DESCRIPTION
... because `nix` utilities will sometimes return warnings and other information to `stderr`. The type of `inprocWithErr` makes it pretty clear that we should expect a result of _either_ the stderr text _or_ the stdout text. Not both! Normally, this is fine because errors will be returned on `stderr`, however this is problematic when nix outputs warnings as the utility will end up treating them as errors.

So we need a function that will give us both and that's `procStrictWithErr`.