### PR TITLE
Relax upper bound on `turtle` from `< 1.6` to `< 1.7`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
   no longer supports them as of hnix-0.15.
 - Support hnix-0.15 and hnix-0.16.
 - Support and require optparse-generic-1.4.0 or higher.
+- Support turtle-1.6
 
 ## 1.0.7
 ### Changed

--- a/hocker.cabal
+++ b/hocker.cabal
@@ -102,7 +102,7 @@ library
                 text                 >= 1.2,
                 time                 >= 1.4,
                 transformers         >= 0.4,
-                turtle               >= 1.3.0 && < 1.6,
+                turtle               >= 1.3.0 && < 1.7,
                 unordered-containers >= 0.2,
                 uri-bytestring       >= 0.2,
                 vector               >= 0.11,


### PR DESCRIPTION
Changelog: https://hackage.haskell.org/package/turtle-1.6.2/changelog
There was a breaking change in 1.6.0 release, but the only use of Tutrle in this package I found is in `src/Data/Docker/Nix/Lib.hs` (to call `nixhash`), which should not be affected by this breaking change.