### PR TITLE
Add support for manifest lists

### DIFF
--- a/hocker-config/Main.hs
+++ b/hocker-config/Main.hs
@@ -30,6 +30,7 @@ progSummary = "Fetch a docker image config JSON from the registry"
 main :: IO ()
 main = unwrapRecord progSummary >>= \Options{..} -> do
   let dockerRegistry = fromMaybe defaultRegistry registry
+      imageArch      = fromMaybe systemArch arch
 
   auth   <- mkAuth dockerRegistry imageName credentials
   config <- Docker.Image.fetchConfig $

--- a/hocker-image/Main.hs
+++ b/hocker-image/Main.hs
@@ -32,6 +32,7 @@ progSummary = "Fetch a docker image from a docker registry without using docker"
 main :: IO ()
 main = unwrapRecord progSummary >>= \Options{..} -> do
   let dockerRegistry = fromMaybe defaultRegistry registry
+      imageArch      = fromMaybe systemArch arch
 
   auth <- mkAuth dockerRegistry imageName credentials
   img  <- withSystemTempDirectory "hocker-image-XXXXXX" $ \d ->

--- a/hocker-layer/Main.hs
+++ b/hocker-layer/Main.hs
@@ -67,6 +67,7 @@ main = unwrapRecord progSummary >>= \ProgArgs{..} -> do
     HockerMeta
       { outDir     = Nothing
       , imageLayer = Just imageLayer
+      , imageArch  = systemArch
       , ..
       }
   either (Hocker.Lib.exitProgFail . show) Prelude.putStrLn layerPath

--- a/hocker-manifest/Main.hs
+++ b/hocker-manifest/Main.hs
@@ -30,6 +30,7 @@ progSummary = "Pull a docker image manifest from the registry"
 main :: IO ()
 main = unwrapRecord progSummary >>= \Options{..} -> do
   let dockerRegistry =  fromMaybe defaultRegistry registry
+      imageArch      =  fromMaybe systemArch arch
 
   auth     <- mkAuth dockerRegistry imageName credentials
   manifest <- Docker.Image.fetchImageManifest $

--- a/hocker.cabal
+++ b/hocker.cabal
@@ -81,6 +81,7 @@ library
                 foldl                >= 1.0,
                 hnix                 >= 0.9.0,
                 http-client          >= 0.4,
+                http-client-tls      >= 0.3 && < 0.4,
                 http-types           >= 0.9.1,
                 lens                 >= 4.0,
                 lens-aeson           >= 1.0,


### PR DESCRIPTION
Amazon ecr responds with manifest list irrespective of what we mention in the Accept header. Added an `--arch` option, that defaults to builtin arch, to fetch manifest & config files for only the required arch.

Strips Authorization Header when following redirects, this is necessary when making requests to AWS as well as curl's default behaviour

I haven't changed the nix code to pass a system option, so it should default to the build machine

Closes #21