### PR TITLE
Test with GHC 9.4-9.12, switch to crypton

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,13 +19,13 @@ jobs:
           - ghc912
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v3.0.2
+      - uses: actions/checkout@v5
         name: Checkout
-      - uses: cachix/install-nix-action@v20
+      - uses: cachix/install-nix-action@v31
         name: Install Nix
         with:
           nix_path: nixpkgs=./nix/pkgs.nix
-      - uses: cachix/cachix-action@v12
+      - uses: cachix/cachix-action@v16
         name: Set up Cachix
         with:
           name: awakesecurity

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,8 +5,19 @@ on:
       - master
   pull_request:
 jobs:
-  build-linux:
-    runs-on: ubuntu-latest
+  build:
+    strategy:
+      matrix:
+        os:
+          - ubuntu-latest
+          - macos-latest
+        compiler:
+          - ghc94
+          - ghc96
+          - ghc98
+          - ghc910
+          - ghc912
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3.0.2
         name: Checkout
@@ -20,21 +31,4 @@ jobs:
           name: awakesecurity
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
       - run: nix-build
-        name: nix-build
-
-  build-macos:
-    runs-on: macos-latest
-    steps:
-      - uses: actions/checkout@v3.0.2
-        name: Checkout
-      - uses: cachix/install-nix-action@v20
-        name: Install Nix
-        with:
-          nix_path: nixpkgs=./nix/pkgs.nix
-      - uses: cachix/cachix-action@v12
-        name: Set up Cachix
-        with:
-          name: awakesecurity
-          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
-      - run: nix-build
-        name: nix-build
+        name: nix-build --argstr compiler "${{ matrix.compiler }}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 - Support and require optparse-generic-1.4.0 or higher.
 - Support turtle-1.6 and turtle
 - Add the `--credentials-file` option to allow passing credentials as a file.
+- Test with GHC 9.4, 9.6, 9.8, 9.10, 9.12
+- Switch from cryptonite to crypton
 
 ## 1.0.7
 ### Changed

--- a/default.nix
+++ b/default.nix
@@ -1,6 +1,6 @@
+{ compiler ? "ghc910" }:
 let
-  pkgs = import ./nix/pkgs.nix;
-
+  pkgs = import ./nix/pkgs.nix { inherit compiler; };
 in
 {
   inherit (pkgs.haskellPackages) hocker;

--- a/hocker.cabal
+++ b/hocker.cabal
@@ -70,7 +70,7 @@ library
                 aeson-pretty         >= 0.8,
                 bytestring           >= 0.10,
                 concurrentoutput     >= 0.2,
-                cryptonite           >= 0.13,
+                crypton              >= 0.32,
                 data-fix             >= 0.0.3,
                 deepseq              >= 1.4,
                 directory            >= 1.2.2.0,
@@ -120,7 +120,7 @@ executable hocker-layer
   ghc-options:         -threaded -rtsopts -with-rtsopts=-N -Wall -Werror -Wunused-packages
   build-depends:
                 base                 >= 4.9 && < 5,
-                cryptonite           >= 0.13,
+                crypton              >= 0.32,
                 hocker,
                 optparse-generic     >= 1.2.0,
                 text                 >= 1.2

--- a/hocker.cabal
+++ b/hocker.cabal
@@ -12,7 +12,11 @@ category:            Utilities
 build-type:          Simple
 
 cabal-version:       >=1.10
-Tested-With:         GHC == 8.0.2
+Tested-With:         GHC == 9.4.8
+                     GHC == 9.6.7
+                     GHC == 9.8.4
+                     GHC == 9.10.3
+                     GHC == 9.12.2
 Description:
     @hocker@ is a suite of command line utilities and a library for:
     .

--- a/nix/overlays/haskell-packages.nix
+++ b/nix/overlays/haskell-packages.nix
@@ -1,3 +1,4 @@
+{ compiler }:
 pkgsFinal: pkgsPrev:
 
 let
@@ -7,8 +8,8 @@ let
 
 in
 {
-  haskellPackages =
-    pkgsPrev.haskellPackages.override (old: {
+  haskellPackages = 
+    pkgsPrev.haskell.packages.${compiler}.override (old: {
       overrides =
         pkgsPrev.lib.fold
           pkgsPrev.lib.composeExtensions

--- a/nix/overlays/haskell-packages.nix
+++ b/nix/overlays/haskell-packages.nix
@@ -16,6 +16,11 @@ in
           (old.overrides or (_: _: { }))
           [
             extension
+
+            (haskellPackagesNew: haskellPackagesOld: {
+              # hnix still depends on cryptonite and not crypton and the tests fail with GHC 9.12
+              cryptonite = pkgsFinal.haskell.lib.compose.dontCheckIf (pkgsFinal.lib.versionAtLeast haskellPackagesNew.ghc.version "9.12") haskellPackagesOld.cryptonite;
+            })
           ];
     });
 }

--- a/nix/pkgs.nix
+++ b/nix/pkgs.nix
@@ -1,3 +1,4 @@
+{ compiler ? "ghc910" }:
 let
   # "nixos-unstable" as on 2024-12-02
   rev = "ac35b104800bff9028425fec3b6e8a41de2bbfff";
@@ -13,6 +14,6 @@ in
 import nixpkgs {
   config = { allowUnfree = true; };
   overlays = [
-    (import ./overlays/haskell-packages.nix)
+    (import ./overlays/haskell-packages.nix { inherit compiler; })
   ];
 }

--- a/nix/pkgs.nix
+++ b/nix/pkgs.nix
@@ -1,9 +1,9 @@
 { compiler ? "ghc910" }:
 let
-  # "nixos-unstable" as on 2024-12-02
-  rev = "ac35b104800bff9028425fec3b6e8a41de2bbfff";
+  # "nixos-unstable" as on 2025-11-12
+  rev = "9da7f1cf7f8a6e2a7cb3001b048546c92a8258b4";
 
-  sha256 = "sha256:1fbj7shlmviilmgz5z2gp59j6xwgdr01jfh75qhixx06kib4305p";
+  sha256 = "sha256:04h7cq8rp8815xb4zglkah4w6p2r5lqp7xanv89yxzbmnv29np2a";
 
   nixpkgs = builtins.fetchTarball {
     url = "https://github.com/NixOS/nixpkgs/archive/${rev}.tar.gz";

--- a/shell.nix
+++ b/shell.nix
@@ -1,5 +1,6 @@
+{ compiler ? "ghc910" }:
 let
-  pkgs = import ./nix/pkgs.nix;
+  pkgs = import ./nix/pkgs.nix { inherit compiler; };
 
   hocker = pkgs.haskellPackages.hocker;
 


### PR DESCRIPTION
- Test with 9.4.8, 9.6.7, 9.8.4, 9.10.3, 9.12.2
- Use latest nixos-unstable channel
- Make GHC version parametrized
- Switch to crypton (hnix still depends on cryptonite)